### PR TITLE
Fix Phala deploy, remove version from docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ The `docker-compose.yaml` contains all of the information necessary to deploy a 
 
 You will need to update this file to reflect your docker hub account, repository name and the sha256 hash of your docker image (this is visible in the CLI after you push your build to docker hub).
 
-On Phala Cloud, click on `deploy` then select `from sketch` and click the `advanced` tab. Paste in the `yaml` and give the instance a name. Check resources and deploy.
+On Phala Cloud, click on `deploy` then select `from docker compose` and click the `advanced` tab. Paste in the `yaml` and give the instance a name. Check resources (defaults `prod5`, `dstack-dev-0.3.5`, and `tdx.small` work) and deploy.
 
 That's it!
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '4.0'
 services:
     web:
         platform: linux/amd64 # Explicitly set for TDX


### PR DESCRIPTION
It seems Phala has done an update and moved to Docker Compose V2  -- so following the current steps results in a failed deploy:

> ... `version` is obsolete
> ... Error response from daemon: unknown: manifest schema unsupported

Removing version is recommended and fixes the issue