### PR TITLE
version bump and node check

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,15 +9,18 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "ethers": "^6.11.1",
-    "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "ethers": "^6.15.0",
+    "react": "^19.1.1",
+    "react-dom": "^19.1.1"
   },
   "devDependencies": {
-    "@vitejs/plugin-react": "^4.6.0",
+    "@vitejs/plugin-react": "^5.0.1",
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.6",
-    "tailwindcss": "^4.1.11",
-    "vite": "^7.0.3"
+    "tailwindcss": "^4.1.12",
+    "vite": "^7.1.3"
+  },
+  "engines": {
+    "node": "^20.19.0 || >=22.12.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,17 +14,17 @@
     "phala:deploy": "phala cvms create --name my-app --vcpu 1 --compose ./docker-compose.yaml --env-file ./.env.development.local"
   },
   "dependencies": {
-    "@hono/node-server": "^1.15.0",
-    "@neardefi/shade-agent-js": "^1.0.0",
-    "chainsig.js": "^1.1.9",
+    "@hono/node-server": "^1.19.0",
+    "@neardefi/shade-agent-js": "^1.0.4",
+    "chainsig.js": "^1.1.11",
     "cors": "^2.8.5",
-    "dotenv": "^16.5.0",
-    "ethers": "^6.11.1",
-    "hono": "^4.8.4"
+    "dotenv": "^17.2.1",
+    "ethers": "^6.15.0",
+    "hono": "^4.9.4"
   },
   "devDependencies": {
-    "@types/node": "^20.0.0",
-    "tsx": "^4.0.0",
-    "typescript": "^5.0.0"
+    "@types/node": "^24.3.0",
+    "tsx": "^4.20.5",
+    "typescript": "^5.9.2"
   }
 }


### PR DESCRIPTION
Updates all dependencies to recent releases eliminating 7 severe vulnerabilities.  Adds minimum node version check to frontend (as well as updating dependencies) to eliminate warnings during npm i.  All functionality still working locally.