### PR TITLE
feat: update for shade-agent-cli-2.4.0, shade-agent-js-2.2.0, shade-attestation-0.2.0

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 save-exact=true
-min-release-age=7d

--- a/agent-contract/Cargo.lock
+++ b/agent-contract/Cargo.lock
@@ -3831,9 +3831,9 @@ dependencies = [
 
 [[package]]
 name = "shade-attestation"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052f350de2a713556da79e4765d75a2a85181d1112bd773b414a3991874ec1aa"
+checksum = "ca13cb03d303d73cb786a6bb2e80d0234d146914fd06fc92a586b4a1dbab8cbf"
 dependencies = [
  "borsh",
  "dcap-qvl",

--- a/agent-contract/Cargo.toml
+++ b/agent-contract/Cargo.toml
@@ -26,7 +26,7 @@ crate-type = ["cdylib", "rlib"]
 hex = { version = "=0.4.3", default-features = false, features = ["alloc"] }
 near-sdk = "=5.26.1"
 serde = { version = "=1.0.228", features = ["derive"] }
-shade-attestation = "=0.1.1"
+shade-attestation = "=0.2.0"
 
 [dev-dependencies]
 near-api = "=0.8.6"
@@ -34,7 +34,7 @@ near-api-types = "=0.8.6"
 near-sandbox = "=0.3.9"
 near-sdk = { version = "=5.26.1", features = ["unit-testing"] }
 serde_json = "=1.0.149"
-shade-attestation = "=0.1.1"
+shade-attestation = "=0.2.0"
 tokio = { version = "=1.52.1", features = ["full"] }
 
 [profile.release]

--- a/agent-contract/src/internal/attestation.rs
+++ b/agent-contract/src/internal/attestation.rs
@@ -4,8 +4,8 @@ impl Contract {
     pub(crate) fn verify_attestation(
         &self,
         attestation: DstackAttestation,
-    ) -> (FullMeasurementsHex, Ppid) {
-        let result: (FullMeasurementsHex, Ppid) = match self.requires_tee {
+    ) -> (FullMeasurementsHex, Ppid, Vec<String>) {
+        let result: (FullMeasurementsHex, Ppid, Vec<String>) = match self.requires_tee {
             true => {
                 // Verify account_ID is an implicit account ID
                 let account_id_str = env::predecessor_account_id().to_string();
@@ -42,9 +42,11 @@ impl Contract {
                     &expected_measurements,
                     &approved_ppids,
                 ) {
-                    Ok((verified_measurements, verified_ppid)) => {
-                        (verified_measurements.into(), verified_ppid)
-                    }
+                    Ok(AcceptedDstackAttestation {
+                        measurements,
+                        ppid,
+                        advisory_ids,
+                    }) => (measurements.into(), ppid, advisory_ids),
                     Err(e) => {
                         panic!("Attestation verification failed: {}", e);
                     }
@@ -66,7 +68,7 @@ impl Contract {
                     self.approved_ppids.contains(&Ppid::default()),
                     "Default PPID must be approved for local mode"
                 );
-                (default_measurements, Ppid::default())
+                (default_measurements, Ppid::default(), Vec::new())
             }
         };
         result

--- a/agent-contract/src/internal/events.rs
+++ b/agent-contract/src/internal/events.rs
@@ -3,6 +3,22 @@ use crate::*;
 const EVENT_STANDARD: &str = "shade-contract-template";
 const EVENT_STANDARD_VERSION: &str = "1.0.0";
 
+/// Maximum number of advisory IDs surfaced in an event; the full count is reported
+/// separately via `number_of_advisory_ids` to keep event/log size bounded.
+pub const MAX_ADVISORY_IDS: usize = 8;
+
+/// Caps advisory IDs to at most [`MAX_ADVISORY_IDS`] for [`Event::AgentRegistered`],
+/// returning the capped list together with the true total.
+pub fn summarize_advisory_ids(advisory_ids: &[String]) -> (Vec<String>, u16) {
+    let number_of_advisory_ids = u16::try_from(advisory_ids.len()).unwrap_or(u16::MAX);
+    let advisory_ids_truncated = advisory_ids
+        .iter()
+        .take(MAX_ADVISORY_IDS)
+        .cloned()
+        .collect();
+    (advisory_ids_truncated, number_of_advisory_ids)
+}
+
 #[derive(Serialize, Debug, Clone)]
 #[serde(crate = "near_sdk::serde")]
 #[serde(tag = "event", content = "data")]
@@ -13,6 +29,8 @@ pub enum Event<'a> {
         account_id: &'a AccountId,
         measurements: &'a FullMeasurementsHex,
         ppid: &'a Ppid,
+        advisory_ids_truncated: Vec<String>,
+        number_of_advisory_ids: u16,
         current_time_ms: U64,
         valid_until_ms: U64,
         // Cannot log attestation, it's too large

--- a/agent-contract/src/internal/unit_tests.rs
+++ b/agent-contract/src/internal/unit_tests.rs
@@ -345,16 +345,14 @@ fn test_remove_agent_not_owner() {
     contract.remove_agent(agent);
 }
 
-// Test that a whitelisted agent can register with sufficient deposit
+// Happy path: first-time registration must attach sufficient storage deposit
 #[test]
-fn test_register_agent_without_tee() {
+fn test_register_agent_happy_first_registration_with_storage_deposit() {
     let mut contract = setup_contract();
     let agent = accounts(2);
 
-    // Owner whitelists the agent (default measurements and PPID already approved in setup)
     contract.whitelist_agent_for_local(agent.clone());
 
-    // Agent registers with fake attestation and 0.005 NEAR deposit
     let context = get_context_with_deposit(agent.clone(), false, Some(DEPOSIT_005_NEAR));
     testing_env!(context.build());
 
@@ -365,31 +363,29 @@ fn test_register_agent_without_tee() {
     assert!(matches!(agent_info.validity, AgentValidity::Valid));
 }
 
-// Test that an agent can register twice and the registration is updated
+// Happy path: first registration with deposit, then re-register with zero (no extra storage)
 #[test]
-fn test_register_agent_twice() {
+fn test_register_agent_happy_reregister_without_additional_deposit() {
     let mut contract = setup_contract();
     let agent = accounts(2);
 
     contract.whitelist_agent_for_local(agent.clone());
 
-    // Register agent first time with 0.005 NEAR deposit
     let context = get_context_with_deposit(agent.clone(), false, Some(DEPOSIT_005_NEAR));
     testing_env!(context.build());
-    let result = contract.register_agent(create_mock_dstack_attestation());
-    assert!(result);
+    assert!(contract.register_agent(create_mock_dstack_attestation()));
+    assert!(matches!(
+        contract.get_agent(agent.clone()).unwrap().validity,
+        AgentValidity::Valid
+    ));
 
-    let agent_info = contract.get_agent(agent.clone()).unwrap();
-    assert!(matches!(agent_info.validity, AgentValidity::Valid));
-
-    // Register agent again with 0.005 NEAR deposit
-    let context = get_context_with_deposit(agent.clone(), false, Some(DEPOSIT_005_NEAR));
+    let context = get_context_with_deposit(agent.clone(), false, Some(DEPOSIT_ZERO));
     testing_env!(context.build());
-    let result = contract.register_agent(create_mock_dstack_attestation());
-    assert!(result);
-
-    let agent_info = contract.get_agent(agent.clone()).unwrap();
-    assert!(matches!(agent_info.validity, AgentValidity::Valid));
+    assert!(contract.register_agent(create_mock_dstack_attestation()));
+    assert!(matches!(
+        contract.get_agent(agent.clone()).unwrap().validity,
+        AgentValidity::Valid
+    ));
 }
 
 // Test that an agent cannot register if not whitelisted for local
@@ -404,10 +400,10 @@ fn test_register_agent_not_whitelisted() {
     contract.register_agent(create_mock_dstack_attestation());
 }
 
-// Test that register_agent fails with insufficient deposit (0 NEAR)
+// First-time registration requires storage stake: zero attached deposit must fail
 #[test]
 #[should_panic(expected = "Attached deposit must be greater than storage cost")]
-fn test_register_agent_insufficient_deposit_zero() {
+fn test_register_agent_errors_when_storage_deposit_required_but_zero_attached() {
     let mut contract = setup_contract();
     let agent = accounts(2);
 
@@ -420,10 +416,10 @@ fn test_register_agent_insufficient_deposit_zero() {
     contract.register_agent(create_mock_dstack_attestation());
 }
 
-// Test that register_agent fails with insufficient deposit (0.003 NEAR)
+// First-time registration: attached deposit below storage cost must fail
 #[test]
 #[should_panic(expected = "Attached deposit must be greater than storage cost")]
-fn test_register_agent_insufficient_deposit_low() {
+fn test_register_agent_errors_when_storage_deposit_insufficient() {
     let mut contract = setup_contract();
     let agent = accounts(2);
 
@@ -1110,4 +1106,49 @@ fn test_get_agents_expiration_fields() {
         matches!(agent1_info.validity, AgentValidity::Invalid(ref r) if r.contains(&AgentRemovalReason::ExpiredAttestation))
     );
     assert!(matches!(agent2_info.validity, AgentValidity::Valid));
+}
+
+// -------- summarize_advisory_ids (AgentRegistered event payload) --------
+
+use super::events::{MAX_ADVISORY_IDS, summarize_advisory_ids};
+
+// Builds `n` distinct advisory IDs in a stable order.
+fn advisory_ids(n: usize) -> Vec<String> {
+    (0..n).map(|i| format!("INTEL-DOC-{i}")).collect()
+}
+
+// No advisories: empty list and a zero count.
+#[test]
+fn summarize_advisory_ids_empty() {
+    let (shown, total) = summarize_advisory_ids(&[]);
+    assert!(shown.is_empty());
+    assert_eq!(total, 0);
+}
+
+// Fewer than the cap: every ID is returned, in order, with the exact count.
+#[test]
+fn summarize_advisory_ids_below_cap() {
+    let ids = advisory_ids(3);
+    let (shown, total) = summarize_advisory_ids(&ids);
+    assert_eq!(shown, ids);
+    assert_eq!(total, 3);
+}
+
+// Exactly at the cap: every ID is returned and none are dropped.
+#[test]
+fn summarize_advisory_ids_at_cap() {
+    let ids = advisory_ids(MAX_ADVISORY_IDS);
+    let (shown, total) = summarize_advisory_ids(&ids);
+    assert_eq!(shown, ids);
+    assert_eq!(total as usize, MAX_ADVISORY_IDS);
+}
+
+// More than the cap: the shown list is truncated to the first `MAX_ADVISORY_IDS`,
+// but the reported total still reflects the true number of advisories.
+#[test]
+fn summarize_advisory_ids_above_cap_truncates_but_counts_all() {
+    let ids = advisory_ids(MAX_ADVISORY_IDS + 4);
+    let (shown, total) = summarize_advisory_ids(&ids);
+    assert_eq!(shown.as_slice(), &ids[..MAX_ADVISORY_IDS]);
+    assert_eq!(total as usize, MAX_ADVISORY_IDS + 4);
 }

--- a/agent-contract/src/lib.rs
+++ b/agent-contract/src/lib.rs
@@ -102,7 +102,7 @@ impl Contract {
         }
 
         // Verify the attestation and get the measurements and PPID for the agent
-        let (measurements, ppid, advisory_ids) = self.verify_attestation(attestation.clone());
+        let (measurements, ppid, advisory_ids) = self.verify_attestation(attestation);
 
         let valid_until_ms = block_timestamp_ms() + self.attestation_expiration_time_ms;
         let (advisory_ids_truncated, number_of_advisory_ids) =

--- a/agent-contract/src/lib.rs
+++ b/agent-contract/src/lib.rs
@@ -10,7 +10,7 @@ use near_sdk::{
     store::{IterableMap, IterableSet},
 };
 use shade_attestation::{
-    attestation::DstackAttestation,
+    attestation::{AcceptedDstackAttestation, DstackAttestation},
     measurements::{FullMeasurements, FullMeasurementsHex, create_mock_full_measurements_hex},
     report_data::ReportData,
     tcb_info::HexBytes,
@@ -102,14 +102,18 @@ impl Contract {
         }
 
         // Verify the attestation and get the measurements and PPID for the agent
-        let (measurements, ppid) = self.verify_attestation(attestation.clone());
+        let (measurements, ppid, advisory_ids) = self.verify_attestation(attestation.clone());
 
         let valid_until_ms = block_timestamp_ms() + self.attestation_expiration_time_ms;
+        let (advisory_ids_truncated, number_of_advisory_ids) =
+            internal::events::summarize_advisory_ids(&advisory_ids);
 
         Event::AgentRegistered {
             account_id: &predecessor,
             measurements: &measurements,
             ppid: &ppid,
+            advisory_ids_truncated,
+            number_of_advisory_ids,
             current_time_ms: U64::from(block_timestamp_ms()),
             valid_until_ms: U64::from(valid_until_ms),
         }

--- a/agent-contract/tests/attestation_tests.rs
+++ b/agent-contract/tests/attestation_tests.rs
@@ -956,8 +956,8 @@ async fn test_attestation_expiration() -> Result<(), Box<dyn std::error::Error +
 
 /// First-time `register_agent` must attach storage stake; zero deposit fails until then.
 #[tokio::test]
-async fn test_register_agent_new_agent_requires_storage_deposit_integration(
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+async fn test_register_agent_new_agent_requires_storage_deposit_integration()
+-> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let sandbox = near_sandbox::Sandbox::start_sandbox().await?;
     let network_config = create_network_config(&sandbox);
     let (genesis_account_id, genesis_signer) = setup_genesis_account().await;
@@ -1028,7 +1028,9 @@ async fn test_register_agent_new_agent_requires_storage_deposit_integration(
         &network_config,
     )
     .await?;
-    let agent = agent_info.data.expect("agent should be registered after first success");
+    let agent = agent_info
+        .data
+        .expect("agent should be registered after first success");
     assert!(
         matches!(agent.validity, AgentValidity::Valid),
         "Agent should be valid after first registration"
@@ -1038,8 +1040,8 @@ async fn test_register_agent_new_agent_requires_storage_deposit_integration(
 }
 
 #[tokio::test]
-async fn test_register_agent_reregister_without_storage_deposit_integration(
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+async fn test_register_agent_reregister_without_storage_deposit_integration()
+-> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let sandbox = near_sandbox::Sandbox::start_sandbox().await?;
     let network_config = create_network_config(&sandbox);
     let (genesis_account_id, genesis_signer) = setup_genesis_account().await;

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -65,6 +65,8 @@ approve_measurements:
   # for local it will be set to default measurements (all zeros)
   # for TEE and docker disabled it will be set to the measurements based on the current docker-compose file
   # for TEE and docker enabled it will be set to the measurements based on the docker-compose file once it has been updated
+  # and on the configurations in deploy_to_phala (dstack_version, instance_type, public_logs and public_sysinfo)
+  # are required when using the <MEASUREMENTS> tag
   args: |
     {
       "measurements": <MEASUREMENTS>
@@ -104,8 +106,9 @@ deploy_to_phala:
   enabled: true
   app_name: my-first-agent
   env_file_path: ./.env
+  # The dstack OS version the agent is deployed with
   dstack_version: 0.5.8
-  # Corresponds to the virtual hardware given to the TEE
+  # The virtual hardware given to the TEE
   instance_type: tdx.small
   # If true TEE logs are public
   public_logs: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "2.0.1",
-        "@neardefi/shade-agent-js": "2.1.0",
-        "chainsig.js": "1.1.15",
+        "@neardefi/shade-agent-js": "2.2.0",
+        "chainsig.js": "1.1.16",
         "cors": "2.8.6",
         "dotenv": "17.4.2",
         "ethers": "6.16.0",
@@ -277,9 +277,9 @@
       }
     },
     "node_modules/@hackylabs/deep-redact": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@hackylabs/deep-redact/-/deep-redact-3.0.4.tgz",
-      "integrity": "sha512-N0YS4KgBfoqwt90BwjPTDGriZUEFG0xKcU5DI/qKR6d8X731Ump/7sSefUMkccbS6MZ3P9T65ED99KHnn06FEA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@hackylabs/deep-redact/-/deep-redact-3.0.5.tgz",
+      "integrity": "sha512-CI6TJytOngHiD9RCjBBwsBrg5kCkyK74RBxawLCQ8b6yOzDgIPN4/zRI/YvL6IV18Xcb6HI93Fo2bzJ19efNqQ==",
       "license": "MIT",
       "funding": {
         "url": "https://ko-fi.com/hackylabs"
@@ -601,21 +601,22 @@
       }
     },
     "node_modules/@neardefi/shade-agent-js": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@neardefi/shade-agent-js/-/shade-agent-js-2.1.0.tgz",
-      "integrity": "sha512-DGji9rMKgEk2V69pD9L/QLoSHI0FtqlVCbvHp8NXNISw69ekKYO5w3hxDJBxGfKg4wsDgpoiWmnMX9Z6C7FFcQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@neardefi/shade-agent-js/-/shade-agent-js-2.2.0.tgz",
+      "integrity": "sha512-+Zk2DkrW8jfa3UhgNakXhzvjiAxEouZTy80YUExvFmHYSqgdvdxxGojA85MeRXUpN6u2M78FypW1dZxQ02lEjg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@hackylabs/deep-redact": "^3.0.4",
-        "@near-js/accounts": "^2.5.1",
-        "@near-js/crypto": "^2.5.1",
-        "@near-js/providers": "^2.5.1",
-        "@near-js/signers": "^2.5.1",
-        "@near-js/tokens": "^2.5.1",
-        "@near-js/transactions": "^2.5.1",
-        "@near-js/types": "^2.5.1",
-        "@phala/dstack-sdk": "^0.5.7",
-        "near-seed-phrase": "^0.2.1"
+        "@hackylabs/deep-redact": "3.0.5",
+        "@near-js/accounts": "2.5.1",
+        "@near-js/crypto": "2.5.1",
+        "@near-js/providers": "2.5.1",
+        "@near-js/signers": "2.5.1",
+        "@near-js/tokens": "2.5.1",
+        "@near-js/transactions": "2.5.1",
+        "@near-js/types": "2.5.1",
+        "@phala/dstack-sdk": "0.5.7",
+        "asn1.js": "4.10.1",
+        "near-seed-phrase": "0.2.1"
       }
     },
     "node_modules/@noble/ciphers": {
@@ -1465,9 +1466,9 @@
       }
     },
     "node_modules/chainsig.js": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/chainsig.js/-/chainsig.js-1.1.15.tgz",
-      "integrity": "sha512-EgpeAPJs3mW1iZ21UUq8pHBIc5yjm/m3/PuusaFQH/YbulrTDIyJmfuy0YU+ZFhF9Xu1NtMDalImwrRnnIfEvg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/chainsig.js/-/chainsig.js-1.1.16.tgz",
+      "integrity": "sha512-DGMlAc2A1eVGqU66UuwIGILHknssJHHNSBFad4+/W2grob1+SVmUEH/DyGL77fK9SKKyvkMu/uXH8maNOLlYlA==",
       "license": "MIT",
       "dependencies": {
         "@aptos-labs/ts-sdk": "^2.0.1",
@@ -1477,6 +1478,7 @@
         "@cosmjs/math": "^0.38.1",
         "@cosmjs/proto-signing": "^0.38.1",
         "@cosmjs/stargate": "^0.38.1",
+        "@mysten/bcs": "^1.9.0",
         "@mysten/sui": "^1.30.1",
         "@near-js/accounts": "^2.2.4",
         "@near-js/crypto": "^2.2.4",
@@ -1486,6 +1488,7 @@
         "@near-js/transactions": "^2.2.4",
         "@near-js/types": "^2.2.4",
         "@near-js/utils": "^2.2.4",
+        "@noble/curves": "^1.9.0",
         "@noble/hashes": "^1.8.0",
         "@scure/base": "^1.2.4",
         "@solana/web3.js": "^1.98.0",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   },
   "dependencies": {
     "@hono/node-server": "2.0.1",
-    "@neardefi/shade-agent-js": "2.1.0",
-    "chainsig.js": "1.1.15",
+    "@neardefi/shade-agent-js": "2.2.0",
+    "chainsig.js": "1.1.16",
     "cors": "2.8.6",
     "dotenv": "17.4.2",
     "ethers": "6.16.0",


### PR DESCRIPTION
Syncs the template to the latest framework releases (cli 2.4.0 / js 2.2.0 / attestation 0.2.0).

## JS app
- `@neardefi/shade-agent-js` `2.1.0` → `2.2.0`
- `chainsig.js` `1.1.15` → `1.1.16`
- regenerated `package-lock.json`
- removed `min-release-age=7d` from `.npmrc`

## Contract (`agent-contract`)
- `shade-attestation` `=0.1.1` → `=0.2.0` (deps + dev-deps)
- ported the advisory-IDs change (framework #68): `verify()` now returns `AcceptedDstackAttestation`; `AgentRegistered` event carries `advisory_ids_truncated` + `number_of_advisory_ids`
- updated unit + attestation tests for the new attestation API
- regenerated `agent-contract/Cargo.lock`

## deployment.yaml
- synced explanatory comments (`<MEASUREMENTS>` ↔ `deploy_to_phala`, `dstack_version`, `instance_type`) — no functional change

## Verification
- `npm install` resolves the new versions
- `cargo check --all-targets` passes against attestation 0.2.0

## Follow-ups not in this PR
- `sbom.cyclonedx.json` / `LICENSE-THIRD-PARTY.txt` are stale after the dep bumps and should be regenerated with the usual tooling before release.
- Reproducible wasm build to be produced via the contract builder image.